### PR TITLE
Sl pin gitpod image feb2023

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,4 @@
+image: gitpod/workspace-full:2023-02-27-14-39-56
 tasks:
   - name: todos
     before: |

--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ This is an example React To-Do application using a [DataStax Astra](https://dtsx
 * Provide a fullstack development example using Astra DB as the storage backend
 
 ## How this works
-Once the Astra DB credentials are provided, the necessary tables are created in the database. The webservice will be available on port 8888 once the application has been deployed.
+Once the Astra DB credentials are provided, the necessary tables are created in the database. The webservice will be available on port 8888 once the application has been deployed (_Note_: ignore the message about a service being available on port 3000, what you are looking for is at an URL starting with `https://8888-...`).
 
 [JAMstack](https://jamstack.org/) is a big leap forward in how we can write web applications that are easy to write, deploy, scale, and also maintain. Using this approach means that newly created content is rendered from a content API, while a static render of it is being built into the site for future.


### PR DESCRIPTION
Since March 2023, Gitpod updated their default image which now ships with a newer Node, thereby rendering this sample app faulty as is.

This PR provides a quick fix, simply pinning an older Gitpod image version where everything runs, since effectively it freezes time to Feb 2023.

*NOTE* To test before merging you should open this link (and not the gitpod button on Readme!):
`https://gitpod.io#https://github.com/hemidactylus/todo-astra-jamstack-netlify/tree/SL-pin-gitpod-image-feb2023`